### PR TITLE
chagne tests to no capture to see the output online.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --nocapture 
     - name: Run doc
       run: cargo doc --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
         rustup component add rustfmt;
         cargo fmt -- --check;
       fi
-    - cargo test
+    - cargo test -- --nocapture
     - cargo doc


### PR DESCRIPTION
This is more convenient when looking at the results of the testers.