### PR TITLE
update ubuntu tester.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             toolchain: stable
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            toolchain: stable
+            #- os: macos-12
+            #target: x86_64-apple-darwin
+            #toolchain: stable
             # TODO: also aarch64 / M1
           - os: windows-latest
             target: x86_64-pc-windows-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             toolchain: nightly
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             toolchain: stable
           - os: macos-latest


### PR DESCRIPTION
The ubuntu 18.04 tester was causing issues and it turns out it is deprecated anyway. This updates it to 22.04.