### PR TITLE
Add tester png artifact output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,18 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose -- --nocapture 
+    - name: store artifact image
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: tester-artifact.png
+        path: "examples/example_experiment_1/test_results_binary/*.png"
+    - name: store artifact diff image
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: tester-artifact.png
+        path: "diff.png"
     - name: Run doc
       run: cargo doc --verbose
 

--- a/tests/run_test_example_1.rs
+++ b/tests/run_test_example_1.rs
@@ -52,7 +52,7 @@ fn test_library_run() -> Result<(), Box<dyn std::error::Error>> {
         .arg("AE")
         .arg("examples/example_experiment_1/CPO_figures/weighted_CPO_elastic_oli_ens_A-B-C-Axis_Batlow_g1_sp301_t00001.00000.png")
         .arg("examples/example_experiment_1/test_results_binary/weighted_CPO_elastic_oli_ens_A-B-C-Axis_Batlow_g1_sp301_t00001.00000.png")
-        .arg("null")
+        .arg("examples/example_experiment_1/weighted_CPO_elastic_oli_ens_A-B-C-Axis_Batlow_g1_sp301_t00001.00000.diff.png")
         .assert()
         .success();
     } else {


### PR DESCRIPTION
Adds the png results and diffs as artifacts. Generally useful, but also due to issues in #27 (with probably my font setup) I can't reproduce the tester results, so for new tests I can download, check and upload it until I can reproduce the exact same figures on my computer.